### PR TITLE
Move swerve math to DriveTrain.java

### DIFF
--- a/src/main/java/frc/robot/commands/SwerveDrive.java
+++ b/src/main/java/frc/robot/commands/SwerveDrive.java
@@ -44,7 +44,7 @@ public class SwerveDrive extends CommandBase {
       targetSpeeds[i] = resultantMagnitude;
       targetAngles[i] = resultantDirection;
     };
-
+ 
     Robot.driveTrain.setSpeedMotorOutputs(targetSpeeds);
     
     // wrap 0 to 360 degrees: take difference (error), make between -180 and 180


### PR DESCRIPTION
Lines 28-46 should go in DriveTrain.java. ServeDrive.java will just call a function you create such as Robot.driveTrain.setInput(driverXAxis, driverYAxis, driverSensitivity) which will live in DriveTrain.java and will know how to use the inputs to set its own target angles, and then use PID to calculate motor outputs for angle/speed.

That will help keep the swerve math and joystick control logic separated. It also means that if you are writing an autonomous sequence you can simulate joystick input easily by just calling the same setInput() function with hardcoded values instead of joystick values.